### PR TITLE
Feat: 폼 미리보기 화면 완성

### DIFF
--- a/src/components/CreateForm/ButtonWrap.tsx
+++ b/src/components/CreateForm/ButtonWrap.tsx
@@ -8,6 +8,8 @@ import Modal from './Modal';
 import { FieldListType, FieldType } from 'interfaces/createForm.d';
 import Toast from 'utils/toast';
 import { useNavigate } from 'react-router-dom';
+import WriteFormWrap from 'components/WriteFormWrap';
+import { Form } from 'antd';
 
 const checkEmptyMustInput = (fieldList: FieldListType) => {
   return fieldList.some((field: FieldType) => {
@@ -52,7 +54,9 @@ function CreateFormButtonWrap() {
       </BottomButtonArea>
       {isModalOpen && (
         <Modal title="폼 미리보기" toggleModal={toggleModal}>
-          <div>프리뷰폼 disalbed</div>
+          <Form layout="vertical" autoComplete="off" style={formStyle}>
+            <WriteFormWrap matchData={state.fieldList} />
+          </Form>
         </Modal>
       )}
     </>
@@ -88,3 +92,7 @@ const Button = styled(ButtonStyle)`
       ${color === 'blue' ? theme.button.blue : theme.button.lightgray};
     `};
 `;
+
+const formStyle = {
+  padding: '1rem',
+};

--- a/src/components/WriteFormWrap.tsx
+++ b/src/components/WriteFormWrap.tsx
@@ -1,0 +1,42 @@
+import { Phone, PostCode, File, Agreement, SelectBox, Name } from '../components/WrtieForm/index';
+import { FieldType, FieldListType } from 'interfaces/createForm.d';
+
+interface Props {
+  matchData: FieldListType;
+  setAddress?: (value: string) => void;
+  setUrl?: (value: string) => void;
+}
+
+function WriteFormWrap({ matchData, setUrl, setAddress }: Props) {
+  const tempAction = () => {
+    return;
+  };
+  const componentType = (item: FieldType) => {
+    switch (item.type) {
+      case 'text':
+        return <Name item={item} />;
+      case 'phone':
+        return <Phone item={item} />;
+      case 'address':
+        return <PostCode setAddress={setAddress || tempAction} item={item} />;
+      case 'select':
+        return <SelectBox item={item} />;
+      case 'file':
+        return <File setUrl={setUrl || tempAction} item={item} />;
+      case 'agreement':
+        return <Agreement item={item} />;
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <>
+      {matchData?.map((item, index) => (
+        <div key={index}>{componentType(item)}</div>
+      ))}
+    </>
+  );
+}
+
+export default WriteFormWrap;

--- a/src/components/WrtieForm/SelectBox.tsx
+++ b/src/components/WrtieForm/SelectBox.tsx
@@ -19,8 +19,10 @@ function SelectBox({ item }: componentType) {
       ]}
     >
       <SelectItem>
-        {options?.map((item) => (
-          <Option value={item}>{item}</Option>
+        {options?.map((item, index) => (
+          <Option key={index} value={item}>
+            {item}
+          </Option>
         ))}
       </SelectItem>
     </Form.Item>

--- a/src/components/WrtieForm/index.ts
+++ b/src/components/WrtieForm/index.ts
@@ -1,0 +1,6 @@
+export { default as Agreement } from './Agreement';
+export { default as File } from './File';
+export { default as Name } from './Name';
+export { default as Phone } from './Phone';
+export { default as PostCode } from './PostCode';
+export { default as SelectBox } from './SelectBox';

--- a/src/interfaces/writeForm.ts
+++ b/src/interfaces/writeForm.ts
@@ -5,11 +5,11 @@ export interface componentType {
 }
 
 export interface FileType {
-  setUrl: React.Dispatch<React.SetStateAction<string>>;
+  setUrl: (value: string) => void;
   item: FieldType;
 }
 
 export interface PostCodeType {
-  setAddress: React.Dispatch<React.SetStateAction<string>>;
+  setAddress: (value: string) => void;
   item: FieldType;
 }

--- a/src/pages/WriteFormPage.tsx
+++ b/src/pages/WriteFormPage.tsx
@@ -1,20 +1,14 @@
 import styled from 'styled-components';
 import 'antd/dist/antd.min.css';
 import { Form } from 'antd';
-import Phone from '../components/WrtieForm/Phone';
-import PostCode from '../components/WrtieForm/PostCode';
-import File from '../components/WrtieForm/File';
 import Btn from '../components/ButtonCustom';
-import Agreement from '../components/WrtieForm/Agreement';
 import { userType } from '../interfaces/user';
-import SelectBox from '../components/WrtieForm/SelectBox';
-import Name from '../components/WrtieForm/Name';
 import { UserDataProvider } from 'context/UserDataContext';
 import { useUserListDispatch } from 'context/UserListContext';
-import { useState, useContext, useMemo } from 'react';
+import { useState, useContext, useMemo, useCallback } from 'react';
 import { FormListContext } from 'context/FormListContext';
 import { useNavigate, useParams } from 'react-router-dom';
-import { FieldType } from 'interfaces/createForm.d';
+import WriteFormWrap from 'components/WriteFormWrap';
 
 function WriteFormPage() {
   const [form] = Form.useForm();
@@ -46,24 +40,19 @@ function WriteFormPage() {
     navigate(`/userData/${id}`);
   };
 
-  const componentType = (item: FieldType) => {
-    switch (item.type) {
-      case 'text':
-        return <Name item={item} />;
-      case 'phone':
-        return <Phone item={item} />;
-      case 'address':
-        return <PostCode setAddress={setAddress} item={item} />;
-      case 'select':
-        return <SelectBox item={item} />;
-      case 'file':
-        return <File setUrl={setUrl} item={item} />;
-      case 'agreement':
-        return <Agreement item={item} />;
-      default:
-        return null;
-    }
-  };
+  const handleChangeAddress = useCallback(
+    (value: string) => {
+      setAddress(value);
+    },
+    [setAddress]
+  );
+
+  const handleChangeUrl = useCallback(
+    (value: string) => {
+      setUrl(value);
+    },
+    [setUrl]
+  );
 
   return (
     <UserDataProvider>
@@ -78,9 +67,11 @@ function WriteFormPage() {
           layout="vertical"
           autoComplete="off"
         >
-          {matchData?.map((item, key) => (
-            <div key={key}>{componentType(item)}</div>
-          ))}
+          <WriteFormWrap
+            matchData={matchData}
+            setAddress={handleChangeAddress}
+            setUrl={handleChangeUrl}
+          />
           <ButtonArea>
             <Form.Item shouldUpdate>
               {() => (


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [X] 기능 추가
- [ ] 기능 삭제
- [X] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항

- 폼 미리보기 모달에 예지님께서 만들어두신 type 별 폼 띄우는 코드를 연결했습니다.
- type 별 폼 띄우는 코드는 재사용을 위해 `WriteFormWrap` 컴포넌트로 분리했습니다.
- 컴포넌트 분리에 따라 전달되는 함수들은 리렌더링 방지를 위해 useCallback으로 감싼 함수로 대체해주었습니다.

### 테스트 결과
<img width="487" alt="스크린샷 2022-03-20 오후 4 48 08" src="https://user-images.githubusercontent.com/50618754/159153330-026234c8-ba00-4d69-b565-9cf15d385fde.png">

### Issue
resolved: #28
